### PR TITLE
Add missing appending assignment

### DIFF
--- a/src/routes/movies/[view=list]/+page.svelte
+++ b/src/routes/movies/[view=list]/+page.svelte
@@ -18,6 +18,7 @@
 			if (appending) return;
 
 			try {
+				appending = true;
 				const next = await api.get(fetch, data.endpoint, {
 					page: String(data.next_page)
 				});


### PR DESCRIPTION
As I see it, appending was never used, which resulted in a bug when scrolling quickly.

To replicate the bug 

1. Be on the /movies/trending page
2. Open network tab of your browser and throttle your network to Fast 3G
3. Click an empty space between two movie posters to move scroll focus to the ResultsPage component
4. Hold cmd + down arrow on mac or End-key on windows to scroll to the bottom

Expected result:

One api call per page is made


Actual result:

Some api calls are duplicated

This PR should fix the bug.